### PR TITLE
Suppress warnings

### DIFF
--- a/R/isovist.R
+++ b/R/isovist.R
@@ -42,7 +42,8 @@ get_isovist <- function(occluders, vpoint, rayno = 41, raylen = 100) {
     rays <- get_rays(maxisovist, vpoint)
 
     occ_in_maxisovist <- occluders[occ_intersections, ] |> st_union()
-    rays_outside_occ <- sf::st_difference(rays, occ_in_maxisovist)
+    rays_outside_occ <- sf::st_difference(rays, occ_in_maxisovist) |>
+      suppressWarnings()
 
     # Get furthest vertex of ray segment closest to view point
     nonoccluded_end <- process_rays(rays_outside_occ, "LINESTRING") |>
@@ -93,7 +94,8 @@ process_rays <- function(rays, geom_type) {
 
   rays |>
     sf::st_cast("LINESTRING") |>
-    sf::st_cast("POINT")
+    sf::st_cast("POINT") |>
+    suppressWarnings()
 }
 
 #' Get furthest vertex from a set of points
@@ -110,5 +112,6 @@ get_furthest_vertex <- function(points, id_col = "id") {
     dplyr::slice_tail(n = 2) |>
     dplyr::slice_head(n = 1) |>
     dplyr::summarise(do_union = FALSE, .groups = 'drop') |>
-    sf::st_cast("POINT")
+    sf::st_cast("POINT") |>
+    suppressWarnings()
 }


### PR DESCRIPTION
The warnings originate from the ids being kept when modifying geometries with `sf::st_cast` and `sf::st_difference`. As we are only keeping the ids as attributes during those transformations, I think it is safe to simply suppress the warnings.

Closes #3

When this is merged, https://github.com/CityRiverSpaces/CRiSp/issues/98 can also be closed.