### PR TITLE
Make selection of number of rays more robust

### DIFF
--- a/R/isovist.R
+++ b/R/isovist.R
@@ -44,7 +44,8 @@ get_isovist <- function(viewpoints, occluders = NULL, ray_num = 40,
 #' Get rays from the viewpoints within a maximum isovist
 #'
 #' @param viewpoints object of class sf_POINT or sfc_POINT
-#' @param ray_num number of rays
+#' @param ray_num number of rays. The number of rays per quadrant needs to be a
+#'   whole number, so `ray_num` will be rounded to the closest multiple of four
 #' @param ray_length length of rays
 #'
 #' @return object of class sf_LINESTRING
@@ -54,10 +55,12 @@ get_rays <- function(viewpoints, ray_num = 40, ray_length = 100) {
   if (!all(sf::st_is(viewpoints, "POINT"))) {
     stop("viewpoints must consist of POINT geometries")
   }
-  if (round(ray_num) != ray_num || ray_num <= 0) stop(
-    "ray_num must be a positive whole number"
-  )
-  ray_num <- as.integer(ray_num)
+  if (ray_num <= 0) stop("ray_num must be a positive number")
+  ray_num_rounded <- round(ray_num / 4) * 4
+  if (ray_num_rounded != ray_num) warning(sprintf(
+    "ray_num is rounded to %s", ray_num_rounded
+  ))
+  ray_num <- as.integer(ray_num_rounded)
   if (ray_length <= 0) stop("ray_length must be larger than zero")
 
   # Generate points on the maximum isovist of the given length

--- a/tests/testthat/test-isovist.R
+++ b/tests/testthat/test-isovist.R
@@ -99,6 +99,18 @@ test_that("Rays construction fails for incorrect input arguments", {
   expect_error(get_rays(line, ray_num = ray_num, ray_length = 0))
 })
 
+test_that("The number of rays are rounded to the closest multiple of four", {
+  viewpoint <- sf::st_sfc(sf::st_point(c(0, 1)))
+  # Multiple of four, no warning
+  ray_num <- 40
+  expect_no_warning(get_rays(viewpoint, ray_num = ray_num))
+  # Expect warning otherwise
+  ray_num <- 41  # round down to 40
+  expect_warning(get_rays(viewpoint, ray_num = ray_num), "40")
+  ray_num <- 43  # round up to 44
+  expect_warning(get_rays(viewpoint, ray_num = ray_num), "44")
+})
+
 test_that("Occluding rays without occluders return untouched rays", {
   ray_geoms <- sf::st_sfc(
     sf::st_linestring(cbind(c(0, 1), c(0, 0))),


### PR DESCRIPTION
Number of rays per quadrant should be a whole number.

Solving e.g. https://github.com/CityRiverSpaces/CRiSp/pull/122#issuecomment-2752374562 