### PR TITLE
Isovists should be computed even with fully-occluded rays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Zenodo and CRAN badges #15
 
+## Fixed
+
+- Isovist can now be computed also if some rays are fully occluded #17
+
 # Version 0.1.0 - 2025-04-03
 
 ## Added

--- a/tests/testthat/test-isovist.R
+++ b/tests/testthat/test-isovist.R
@@ -186,3 +186,14 @@ test_that("merge_isovists returns the merged polygon, with or without holes", {
   expected <- sf::st_union(isovists)
   expect_equal(actual, expected)
 })
+
+test_that("visor works with fully occluded rays", {
+  viewpoints <- sf::st_sfc(sf::st_point(c(0, 0)), sf::st_point(c(2, 0)))
+  occluders <- sf::st_sfc(
+    create_occluder(1, 0, 2, 1),
+    create_occluder(3, 1, 1, 1)
+  )
+  expect_no_error(
+    get_isovist(viewpoints, occluders = occluders, ray_length = 1)
+  )
+})


### PR DESCRIPTION
Currently a bug prevent this from working - this is the source of https://github.com/CityRiverSpaces/rcrisp/issues/133